### PR TITLE
ignore js/css/img hosted on a remote server

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ Use the **cacheBust** task for cache busting static files in your application. T
 
 _Currently supported static assets: **CSS**, **JavaScript** and **images**_
 
+_Note:_ Remote URLs for CSS, JavaScript, and images are ignored by cacheBust.  This assumes that remote URLs for these assets will
+be CDN hosted content, typically for well known libraries like jQuery or Bootstrap.  These URLs typically include a version
+identifier in the URL to deal with browser caching, and it is in the best interest of your app to use the standard URL as-is
+to ensure browser cache hits for popular libraries.  For example, all of below URLs will be ignored:
+
+```html
+<link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
+<link href="http://twitter.github.com/bootstrap/assets/css/bootstrap.css" rel="stylesheet">
+<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.0.6/angular.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+<script type="text/javascript" src="http://code.jquery.com/qunit/qunit-1.12.0.js"></script>
+<img src="https://secure.gravatar.com/avatar/d3b2094f1b3386e660bb737e797f5dcc?s=420" alt="test" />
+```
+
 ### Overview
 In your project's Gruntfile, add a section named `cacheBust` to the data object passed into `grunt.initConfig()`.
 

--- a/tasks/cachebust.js
+++ b/tasks/cachebust.js
@@ -6,15 +6,15 @@ module.exports = function(grunt) {
 
     var regexs = {
         js: {
-            src: /<script.+src=['"]([^"']+)["']/gm,
+            src: /<script.+src=['"](?!http:|https:|\/\/)([^"']+)["']/gm,
             file: /src=['"]([^"']+)["']/m
         },
         css: {
-            src: /<link.+href=.*\.css["']/gm,
+            src: /<link.+href=["'](?!http:|https:|\/\/).*\.css["']/gm,
             file: /href=['"]([^"']+)["']/m
         },
         images: {
-            src: /<img[^\>]+src=['"](?!data:image)([^"']+)["']/gm,
+            src: /<img[^\>]+src=['"](?!http:|https:|\/\/|data:image)([^"']+)["']/gm,
             file: /src=['"]([^"']+)["']/m
         }
     };

--- a/test/cachebust_test.js
+++ b/test/cachebust_test.js
@@ -2,7 +2,7 @@ var grunt = require('grunt');
 
 exports.cachebust = {
     scripts: function(test) {
-        test.expect(4);
+        test.expect(7);
 
         var scripts = grunt.file.read('tmp/script.html');
         test.ok(scripts.match(/script1\.js\?[a-z0-9]{16}/), 'testing script1');
@@ -10,23 +10,32 @@ exports.cachebust = {
         test.ok(scripts.match(/script3\.js\?[a-z0-9]{16}/), 'testing script3');
         test.ok(scripts.match(/script4\.js\?[a-z0-9]{16}/), 'testing script4');
 
+        test.ok(scripts.match(/src="\/\/ajax.googleapis.com\/ajax\/libs\/angularjs\/1.0.6\/angular.min.js"/), 'remotely hosted // syntax should remain untouched');
+        test.ok(scripts.match(/src="https:\/\/ajax.googleapis.com\/ajax\/libs\/jquery\/1.10.2\/jquery.min.js"/), 'remotely hosted https:// syntax should remain untouched');
+        test.ok(scripts.match(/src="http:\/\/code.jquery.com\/qunit\/qunit-1.12.0.js"/), 'remotely hosted http:// syntax should remain untouched');
+
         test.done();
     },
 
     stylesheets: function(test) {
-        test.expect(4);
+        test.expect(7);
 
         var stylesheet = grunt.file.read('tmp/stylesheet.html');
+        console.log(stylesheet);
         test.ok(stylesheet.match(/stylesheet1\.css\?[a-z0-9]{16}/), 'testing stylesheet1');
         test.ok(stylesheet.match(/stylesheet2\.css\?[a-z0-9]{16}/), 'testing stylesheet2');
         test.ok(stylesheet.match(/stylesheet3\.css\?[a-z0-9]{16}/), 'testing stylesheet3');
         test.ok(stylesheet.match(/stylesheet4\.css\?[a-z0-9]{16}/), 'testing stylesheet4');
+        
+        test.ok(stylesheet.match(/href="\/\/netdna.bootstrapcdn.com\/twitter-bootstrap\/2.3.2\/css\/bootstrap-combined.min.css"/), 'remotely hosted // syntax should remain untouched');
+        test.ok(stylesheet.match(/href="https:\/\/twitter.github.com\/bootstrap\/assets\/css\/bootstrap.css"/), 'remotely hosted https:// syntax should remain untouched');
+        test.ok(stylesheet.match(/href="http:\/\/twitter.github.com\/bootstrap\/assets\/css\/bootstrap.css"/), 'remotely hosted http:// syntax should remain untouched');
 
         test.done();
     },
 
     images: function(test) {
-        test.expect(16);
+        test.expect(17);
 
         var images = grunt.file.read('tmp/images.html');
         test.ok(images.match(/image1\.jpg\?[a-z0-9]{16}/), 'testing image1 .jpg');
@@ -48,6 +57,8 @@ exports.cachebust = {
         test.ok(images.match(/image3\.webp\?[a-z0-9]{16}/), 'testing image3 .webp');
 
         test.ok(images.match(/src=\"data:image\/png\;base64\,iVBORw0KGgoAAAANS"/), 'testing image4 base64');
+        console.log(images);
+        test.ok(images.match(/src=\"https:\/\/gravatar.example.com\/avatar\/d3b2094f1b3386e660bb737e797f5dcc\?s=420"/), 'remotely hosted https:// syntax should remain untouched');
 
         test.done();
     },

--- a/test/fixtures/images.html
+++ b/test/fixtures/images.html
@@ -17,3 +17,5 @@
 <img width="200" height="300" src="image3.webp" alt="test" title="test">
 
 <img src="data:image/png;base64,iVBORw0KGgoAAAANS" alt="test" />
+
+<img src="https://gravatar.example.com/avatar/d3b2094f1b3386e660bb737e797f5dcc?s=420" alt="test" />

--- a/test/fixtures/script.html
+++ b/test/fixtures/script.html
@@ -2,3 +2,6 @@
 <script defer src="script2.js"></script>
 <script async src="script3.js"></script>
 <script type="text/javascript" src="script4.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.0.6/angular.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+<script type="text/javascript" src="http://code.jquery.com/qunit/qunit-1.12.0.js"></script>

--- a/test/fixtures/stylesheet.html
+++ b/test/fixtures/stylesheet.html
@@ -2,3 +2,6 @@
 <link href="stylesheet2.css" />
 <link rel="stylesheet" href="stylesheet3.css">
 <link href="stylesheet4.css" rel="stylesheet">
+<link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.min.css" rel="stylesheet">
+<link href="http://twitter.github.com/bootstrap/assets/css/bootstrap.css" rel="stylesheet">
+<link href="https://twitter.github.com/bootstrap/assets/css/bootstrap.css" rel="stylesheet">


### PR DESCRIPTION
Hi Ben,

I didn't see a point in hashing href's that are remote URLs, particularly for CDN hosted libraries like AngularJS, jQuery, or Bootstrap.

Here's a copy of my commit msg:

```
ignore js/css/img hosted on a remote server

- cacheBust should ignore files hosted on a CDN as these files typically
  include version strings to identify code changes

- including a hash value in the querystring at best causes a cache miss
  in the browser, causing the browser to redownload already cached
  version of CDN hosted libraries like jQuery, Bootstrap, or AngularJS;
  at worst, the remote server might alter the response based on a the
  querystring parameter

- the current cacheBust implementation does not accurately hash remote
  URLs, as it would need to download the URL to a local file first
```

Thanks,
Steve
