### PR TITLE
Fixing greedy Regex

### DIFF
--- a/tasks/cachebust.js
+++ b/tasks/cachebust.js
@@ -6,11 +6,11 @@ module.exports = function(grunt) {
 
     var regexs = {
         js: {
-            src: /<script.+src=['"](?!http:|https:|\/\/)([^"']+)["']/gm,
+            src: /<script.+?src=['"](?!http:|https:|\/\/)([^"']+?)["']/gm,
             file: /src=['"]([^"']+)["']/m
         },
         css: {
-            src: /<link.+href=["'](?!http:|https:|\/\/).*\.css("|\?.*")/gm,
+            src: /<link.+?href=["'](?!http:|https:|\/\/).+?\.css("|\?.+?")/gm,
             file: /href=['"]([^"']+)["']/m
         },
         images: {

--- a/test/cachebust_test.js
+++ b/test/cachebust_test.js
@@ -21,7 +21,7 @@ exports.cachebust = {
         test.expect(7);
 
         var stylesheet = grunt.file.read('tmp/stylesheet.html');
-        console.log(stylesheet);
+
         test.ok(stylesheet.match(/stylesheet1\.css\?[a-z0-9]{16}/), 'testing stylesheet1');
         test.ok(stylesheet.match(/stylesheet2\.css\?[a-z0-9]{16}/), 'testing stylesheet2');
         test.ok(stylesheet.match(/stylesheet3\.css\?[a-z0-9]{16}/), 'testing stylesheet3');
@@ -57,7 +57,6 @@ exports.cachebust = {
         test.ok(images.match(/image3\.webp\?[a-z0-9]{16}/), 'testing image3 .webp');
 
         test.ok(images.match(/src=\"data:image\/png\;base64\,iVBORw0KGgoAAAANS"/), 'testing image4 base64');
-        console.log(images);
         test.ok(images.match(/src=\"https:\/\/gravatar.example.com\/avatar\/d3b2094f1b3386e660bb737e797f5dcc\?s=420"/), 'remotely hosted https:// syntax should remain untouched');
 
         test.done();
@@ -103,6 +102,23 @@ exports.cachebust = {
         test.ok(standard.match(/standard\.js\?[a-z0-9]{16}/), 'testing combination of CSS, JS and images');
         test.ok(standard.match(/standard\.css\?[a-z0-9]{16}/), 'testing combination of CSS, JS and images');
         test.ok(standard.match(/standard\.jpg\?[a-z0-9]{16}/), 'testing combination of CSS, JS and images');
+
+        test.done();
+    },
+
+    minified: function(test) {
+        test.expect(6);
+
+        var minified = grunt.file.read('tmp/minified.html');
+
+        test.ok(minified.match(/stylesheet1\.css\?[a-z0-9]{16}/), 'testing stylesheet1');
+        test.ok(minified.match(/stylesheet2\.css\?[a-z0-9]{16}/), 'testing stylesheet2');
+
+        test.ok(minified.match(/javascript1\.js\?[a-z0-9]{16}/), 'testing javascript1');
+        test.ok(minified.match(/javascript2\.js\?[a-z0-9]{16}/), 'testing javascript2');
+
+        test.ok(minified.match(/image1\.png\?[a-z0-9]{16}/), 'testing image1');
+        test.ok(minified.match(/image2\.png\?[a-z0-9]{16}/), 'testing image2');
 
         test.done();
     }

--- a/test/fixtures/minified.html
+++ b/test/fixtures/minified.html
@@ -1,0 +1,1 @@
+<link rel="stylesheet" href="stylesheet1.css" /><link rel="stylesheet" href="stylesheet2.css" /><script defer src="javascript1.js" type="text/javascript"></script><script defer src="javascript2.js" type="text/javascript"></script><img src="image1.png" alt="test"><img src="image2.png" alt="test">


### PR DESCRIPTION
Adjusting JS and CSS regex commands to be less greedy, allowing minified HTML to be processed in full.
