### PR TITLE
readme demo code should be options.baseDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ grunt.initConfig({
     options: {
       algorithm: 'sha1',
       length: 32,
-      dir : '.tmp/public/'
+      baseDir : '.tmp/public/'
     },
     files: [{
       expand: true,


### PR DESCRIPTION
according to latest commit [cachebust.js](https://github.com/hollandben/grunt-cache-bust/blob/4f81edecc04043055b1ddc52f3145431c2f866c0/tasks/cachebust.js#L24)
