### PR TITLE
avoid getting multiple same path in findStaticAssets

### DIFF
--- a/tasks/cachebust.js
+++ b/tasks/cachebust.js
@@ -104,7 +104,9 @@ module.exports = function(grunt) {
             }
         }
 
-        return paths;
+        return paths.filter(function(path, index) {
+            return paths.indexOf(path) === index;
+        });
     };
 
     grunt.file.defaultEncoding = options.encoding;


### PR DESCRIPTION
when same paths is written many times in a html file, hash parameter is inserted many times to the path.

for example, when following code is in HTML file,
  &lt;img src="/img/common/t.gif"&gt;
  &lt;img src="/img/common/t.gif"&gt;
grunt-cache-bust genarate following html. 
  &lt;img src="/img/common/t.gif?cbcee5d614fdd537?cbcee5d614fdd537"&gt;
  &lt;img src="/img/common/t.gif?cbcee5d614fdd537?cbcee5d614fdd537"&gt;

So I fixed findStaticAssets method to avoid getting multiple same path.
