### PR TITLE
Fixed parameter override problem

### DIFF
--- a/tasks/cachebust.js
+++ b/tasks/cachebust.js
@@ -222,7 +222,12 @@ module.exports = function(grunt) {
                             grunt.file.delete(filename);
                         }
                     } else {
-                        newFilename = reference.split('?')[0] + '?' + generateHash(grunt.file.read(filename));
+                        if(/\?/.test(reference)) {
+                            newFilename = reference + '&amp;';
+                        } else {
+                            newFilename = reference + '?';
+                        }
+                        newFilename = newFilename + '__cachebust_string__=' + generateHash(grunt.file.read(filename));
                         markup = markup.replace(new RegExp(regexEscape(reference), 'g'), newFilename);
                     }
                 });


### PR DESCRIPTION
# Fixed parameter override problem

I have images added some parameters for creating thumbnails like following sample code.  

```
<img src="/img/foo.png?_ex=120x120">
```

But grunt-cache-bust plugin remove the parameter like this.

```
<img src="/img/foo.png?0e981b41a61cfb73">
```

So I modified source for avoiding this problem.  
If filename has parameter already, the plugin added '&amp;' string instead of '?' string.  
And now, I used `__cachebust_string__` as parameter name.  
But I don't know this name is good or not.  
Anyway, builded result will be changed like follwing after this fix.  

```
<img src="/img/foo.png?_ex=120x120&amp;__cachebust_string__=0e981b41a61cfb73">
```
