### PR TITLE
Adding cdnPath for own CDN-Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ Default value: `true`
 
 When true, `cachebust` will rename the reference to the file and the file itself with the generated hash. When set to false, then a query string parameter is added to the end of the file reference.
 
+#### options.cdnPath
+Type: `String`
+Default value: `false`
+
+When set, `cachebust` test paths against this string when attempts to determine a path to be remote or not.
+So all assets can be busted localy and than uploaded to your own CDN.
+This string will be ignored in paths during file-handling to find files in baseDir.
+
 ### Usage Examples
 
 #### Basic Asset Cache Busting


### PR DESCRIPTION
Hi,

i added an option "cdnPath" for own, single CDN-Handling.

In one project i run an own, cookie-less CDN to avoid useless data transfer
and speed up responses, but building the site with a grunt workflow locally..

With this changes i can tell cachebust to rate paths with this prefix as local.
After busting i can upload the assets to the cdn and the html-files to the webserver 
and everything works beautifully ;)

Maybe you want to implement it to your version.

Cheers,
lietzi