### PR TITLE
Also check for paths in 'xlink:href' attribute.

### DIFF
--- a/tasks/cachebust.js
+++ b/tasks/cachebust.js
@@ -79,7 +79,9 @@ module.exports = function(grunt) {
 
     /** @this Object An elem on which attr() may be called for src or href. */
     var checkIfElemSrcValidFile = function() {
-        return checkIfValidFile(this.attr('src')) || checkIfValidFile(this.attr('href'));
+        return checkIfValidFile(this.attr('src')) || 
+               checkIfValidFile(this.attr('xlink:href') ? this.attr('xlink:href').split('#')[0] : '') || 
+               checkIfValidFile(this.attr('href'));
     };
 
     var findStaticAssets = function(data, filters, isCSS) {


### PR DESCRIPTION
This allows for the possibility of image source being in an [xlink:href](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href) attribute, which can be used for referencing SVG sprites. It also removes any anchor in the path, because it's used to reference a symbol inside the file. See detailed problem description in [this issue](https://github.com/hollandben/grunt-cache-bust/issues/82).