### PR TITLE
Option to remove frag hints after processing

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,7 +76,16 @@ module.exports = function(grunt) {
                     enableUrlFragmentHint: true
                 },
                 files: [{
-                    src: ['tmp/*.php']
+                    src: ['tmp/enableUrlFragmentHint.php']
+                }]
+            },
+            removeUrlFragmentHint: {
+                options: {
+                    enableUrlFragmentHint: true,
+                    removeUrlFragmentHint: true
+                },
+                files: [{
+                    src: ['tmp/removeUrlFragmentHint.php']
                 }]
             },
             fileLevelBaseDirOverride: {

--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ Default value: `false`
 
 When true, cachebust will search single and double-quoted strings in scripting languages such as PHP for asset paths. Asset paths must have the `#grunt-cache-bust` URL fragment appended. See [an example](https://github.com/hollandben/grunt-cache-bust/blob/master/test/fixtures/enableUrlFragmentHint.php) for more details.
 
+#### options.removeUrlFragmentHint
+
+Type: `Boolean`
+Default value: `false`
+
+Removes the URL fragment after it's been processed.
+
 #### options.encoding
 Type: `String`
 Default value: `'utf8'`

--- a/tasks/cachebust.js
+++ b/tasks/cachebust.js
@@ -7,6 +7,7 @@ var options = {
     algorithm: 'md5',
     cdnPath: false,
     deleteOriginals: false,
+    enableUrlFragmentHint: false,
     encoding: 'utf8',
     filters: {},
     ignorePatterns: [],
@@ -14,6 +15,7 @@ var options = {
     jsonOutputFilename: 'cachebuster.json',
     length: 16,
     replaceTerms: [],
+    removeUrlFragmentHint: false,
     rename: true,
     separator: '.'
 };
@@ -144,6 +146,10 @@ module.exports = function(grunt) {
                     processedFileMap[originalFilename] = newReference;
                 }
             });
+
+            if (opts.enableUrlFragmentHint && opts.removeUrlFragmentHint) {
+                markup = markup.replace(regexs.removeFragHint, '');
+            }
 
             // Write back to the source file with changes
             grunt.file.write(filepath, markup);

--- a/tasks/lib/regexs.js
+++ b/tasks/lib/regexs.js
@@ -3,5 +3,6 @@
 module.exports = {
     remote: /http:|https:|\/\/|data:image/,
     extension: /(\.[a-zA-Z0-9]{2,4})(|\?.*)$/,
-    urlFragHint: /'(([^']+)#grunt-cache-bust)'|"(([^"]+)#grunt-cache-bust)"/g
+    urlFragHint: /'(([^']+)#grunt-cache-bust)'|"(([^"]+)#grunt-cache-bust)"/g,
+    removeFragHint: /#grunt-cache-bust/g
 };

--- a/test/fixtures/removeUrlFragmentHint.php
+++ b/test/fixtures/removeUrlFragmentHint.php
@@ -1,0 +1,15 @@
+<?
+
+// Example PHP code where assets are just in static strings and must be explicitly identified
+$foo = 'assets/standard.css#grunt-cache-bust';
+$bar = "assets/image2.jpg#grunt-cache-bust";
+
+?>
+<html>
+<head>
+    <title>Test page</title>
+</head>
+<body>
+    <script type="text/javascript" src="assets/standard.js#grunt-cache-bust"></script>
+</body>
+</html>

--- a/test/url-fragments_test.js
+++ b/test/url-fragments_test.js
@@ -14,6 +14,18 @@ module.exports = {
         test.ok(phpFile.match(/"assets\/standard\.[a-z0-9]{16}\.js\#grunt-cache-bust"/), 'cache bust asset path in double-quoted PHP str');
 
         test.done();
+    },
+
+    removeUrlFragmentHint: function(test) {
+        test.expect(3);
+
+        var phpFile = grunt.file.read('tmp/removeUrlFragmentHint.php');
+
+        test.ok(phpFile.match(/'assets\/standard\.[a-z0-9]{16}\.css'/), 'cache bust asset path in single-quoted PHP str');
+        test.ok(phpFile.match(/"assets\/image2\.[a-z0-9]{16}\.jpg"/), 'cache bust asset path in double-quoted PHP str');
+        test.ok(phpFile.match(/"assets\/standard\.[a-z0-9]{16}\.js"/), 'cache bust asset path in double-quoted PHP str');
+
+        test.done();
     }
 
 };


### PR DESCRIPTION
Finishes #93 

Provides an option to remove the URL fragment hints after processing