### PR TITLE
Fixed issue caused by multiple dots in file name

### DIFF
--- a/tasks/cachebust.js
+++ b/tasks/cachebust.js
@@ -95,7 +95,7 @@ module.exports = function(grunt) {
                     if (processedFileMap[filename]) {
                         markup = markup.replace(new RegExp(utils.regexEscape(reference), 'g'), processedFileMap[filename]);
                     } else {
-                        var hashReplaceRegex = new RegExp(utils.regexEscape(opts.separator) + '(' + (opts.hash ? opts.hash + '|' : '') + '[a-zA-Z0-9]{' + opts.length + '})', 'ig');
+                        var hashReplaceRegex = new RegExp(utils.regexEscape(opts.separator) + '(' + (opts.hash ? opts.hash + '|' : '') + '[a-zA-Z0-9]{' + opts.length + '})\.([^.]*)', 'ig');
 
                         // Get the original filename
                         filename = filename.replace(hashReplaceRegex, '');


### PR DESCRIPTION
Having more than one dot in file name will cause situation when references will not be found in html files.

Example (debug info on screenshots just to make it easier to understand):
with default settings seems like there is no problem at all
![](http://i.imgur.com/MQvWWyS.png)

but if we change options.length to 8 (witch is exactly length of word "prefixed") we will get this
![](http://i.imgur.com/LigdkoG.png)

Improving your RegEx a little we can assure that we getting the right `spot` for our hash, just before last dot.

P.S. Unfortunately my changes breaks some of your tests witch i personally don't see any use of. :(