### PR TITLE
Improved detection of remote resources

### DIFF
--- a/tasks/cachebust.js
+++ b/tasks/cachebust.js
@@ -114,8 +114,11 @@ module.exports = function(grunt) {
                             });
                         }
 
+                        if (utils.checkIfRemote(reference)) {
+                        	return false;	// ignore references to external files
+                        }
                         if (!grunt.file.exists(filename)) {
-                            grunt.log.warn('Static asset "' + filename + '" skipped because it wasn\'t found.');
+                            grunt.log.warn('Static asset "' + filename + '" skipped because it wasn\'t found, original reference=' + reference);
                             return false;
                         }
 
@@ -136,8 +139,11 @@ module.exports = function(grunt) {
                         grunt.verbose.writeln(newFilename + ' was created!');
                     }
                 } else {
-                    if (!grunt.file.exists(filename) && !utils.checkIfRemote(filename)) {
-                        grunt.log.warn('Static asset "' + filename + '" skipped because it wasn\'t found.');
+                    if (utils.checkIfRemote(reference)) {
+                    	return false;	// ignore references to external files
+                    }
+                    if (!grunt.file.exists(filename)) {
+                        grunt.log.warn('Static asset "' + filename + '" skipped because it wasn\'t found, original reference=' + reference);
                         return false;
                     }
 

--- a/tasks/lib/regexs.js
+++ b/tasks/lib/regexs.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-    remote: /http:|https:|\/\/|data:image/,
+    remote: /^http:|^https:|^\/\/|^data:image/i,
     extension: /(\.[a-zA-Z0-9]{2,4})(|\?.*)$/,
     urlFragHint: /'(([^']+)#grunt-cache-bust)'|"(([^"]+)#grunt-cache-bust)"/g,
     removeFragHint: /#grunt-cache-bust/g

--- a/tests/stylesheets/stylesheet.css
+++ b/tests/stylesheets/stylesheet.css
@@ -25,6 +25,12 @@ body {
     background-size: contain;
 }
 
+.external-image {
+	background-image: url('//www.external.com/external-image1.jpg');
+	background-image: url('http://www.external.com/external-image2.jpg');
+	background-image: url('https://www.external.com/external-image3.jpg');
+}
+
 @media only screen and (min-device-pixel-ratio: 2) and (min-resolution: 2dppx) {
     .large-image {
         background-image: url('assets/image1.jpg');

--- a/tests/stylesheets/stylesheet_test.js
+++ b/tests/stylesheets/stylesheet_test.js
@@ -21,7 +21,7 @@ module.exports = {
     },
 
     stylesheet: function(test) {
-        test.expect(5);
+        test.expect(8);
 
         var markup = grunt.file.read('tmp/stylesheets/stylesheet.css');
 
@@ -30,6 +30,9 @@ module.exports = {
         test.ok(markup.match(/css-image-large\.[a-z0-9]{16}\.jpg/), 'testing an image in a CSS file');
         test.ok(markup.match(/image1\.[a-z0-9]{16}\.jpg/), 'testing an image in a CSS file within a media query');
         test.ok(markup.match(/image2\.[a-z0-9]{16}\.jpg/), 'testing an image in a CSS file within a media query');
+        test.ok(markup.match(/'\/\/www\.external\.com\/external-image1.jpg'/), 'testing an external image in a CSS file');
+        test.ok(markup.match(/'http:\/\/www\.external\.com\/external-image2.jpg'/), 'testing an external image in a CSS file');
+        test.ok(markup.match(/'https:\/\/www\.external\.com\/external-image3.jpg'/), 'testing an external image in a CSS file');
 
         test.done();
     },


### PR DESCRIPTION
While trying to get my project working, I noticed that remote resource references from css files were not being detected. Once digging into it, I realized remote resources were being detected inconsistently in other situations as well. I've added the following items which correct all the issues I found along the way:

- test original reference for whether it was remote rather than testing the constructed filename (which may no longer resemble the original reference)
- test remote during rename as well as query parm processing
- ignore case for remote references and ensure patterns are at start of reference
- add some test cases
- add additional debug output when assets are not found (this has been tremendously helpful each time I've been trying to track down an asset that's not found).

*Note: Apologies for whatever happened to regexs.js that caused the whole file to diff. I only intended to change the remote regex line.*

Now back to the original task of trying to get my own project using the newly improved relative path handling. :)

Mike