### PR TITLE
Fixes deleteOriginals option

### DIFF
--- a/tasks/cachebust.js
+++ b/tasks/cachebust.js
@@ -170,14 +170,7 @@ module.exports = function(grunt) {
                     markup = markup.replace(new RegExp(utils.regexEscape(reference), 'g'), newFilename);
                 }
 
-                processedFileMap[originalReference] = newReference;
-
-                // Delete the original files, if enabled
-                if (opts.deleteOriginals) {
-                    if (grunt.file.exists(filename)) {
-                        grunt.file.delete(filename);
-                    }
-                }
+                processedFileMap[filename] = newReference;
             });
 
             if (opts.enableUrlFragmentHint && opts.removeUrlFragmentHint) {
@@ -207,6 +200,15 @@ module.exports = function(grunt) {
                     processFile(file, filepath);
                 });
         });
+
+        // Delete the original files, if enabled
+        if (opts.rename && opts.deleteOriginals) {
+            for (var file in processedFileMap) {
+                if (grunt.file.exists(file)) {
+                    grunt.file.delete(file);
+                }
+            }
+        }
 
         // Generate a JSON with the swapped file names if requested
         if (opts.jsonOutput) {


### PR DESCRIPTION
Hi,

Since the 0.4.12 version, option deleteOriginals does not work when 2 files contain the same static file.
This is the same topic as the issue 122 and the pull request 123.

Before treatment:
– john.html with
```
<img src="foo.png" alt="Foo" />
```
– doe.html with
```
<img src="foo.png" alt="Foo" />
```

After treatment:
– john.html with
```
<img src="foo.XXXXXXXX.png" alt="Foo" />
```
– doe.html with
```
<img src="foo.png" alt="Foo" />
```
→ Static asset "foo.png" skipped because it wasn't found 

Sorry for my english, I'm french :)

Kind regards,
Thomas Orlowski