### PR TITLE
don't convert filecontent to string while hashing (fixes #142)

### DIFF
--- a/config/rename.js
+++ b/config/rename.js
@@ -5,6 +5,6 @@ module.exports = {
     files: [{
         expand: true,
         cwd: 'tmp/rename/',
-        src: ['*.html']
+        src: ['*.html', 'rename.css']
     }]
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "grunt": "~0.4.5"
     },
     "dependencies": {
-        "cheerio": "~0.18.0",
+        "cheerio": "~0.19.0",
         "css": "~2.2.0",
         "flatten": "~0.0.1"
     },

--- a/tasks/cachebust.js
+++ b/tasks/cachebust.js
@@ -136,7 +136,7 @@ module.exports = function(grunt) {
                             return false;
                         }
 
-                        var fileHash = utils.generateFileHash(grunt.file.read(filename));
+                        var fileHash = utils.generateFileHash(grunt.file.read(filename, {encoding: null}));
 
                         // Create our new filename
                         newFilename = utils.addFileHash(filename, fileHash, path.extname(filename), opts.separator);
@@ -164,7 +164,7 @@ module.exports = function(grunt) {
                     // Cater for special `?#iefix` in font face declarations - this isn't pretty
                     reference = reference.replace('?#', '#');
 
-                    newFilename = reference.split('?')[0] + '?' + utils.generateFileHash(grunt.file.read(filename));
+                    newFilename = reference.split('?')[0] + '?' + utils.generateFileHash(grunt.file.read(filename, {encoding: null}));
                     newReference = newFilename;
                     markup = markup.replace(new RegExp(utils.regexEscape(reference), 'g'), newFilename);
                 }

--- a/tasks/lib/findStaticAssets.js
+++ b/tasks/lib/findStaticAssets.js
@@ -88,6 +88,6 @@ module.exports = function(opts, filters) {
             }
         }
 
-        return paths.filter(utils.checkIfValidFile.bind(utils));
+        return paths.filter(utils.checkIfValidFile.bind(utils)).sort(function(a, b) { return b.localeCompare(a); });
     };
 };

--- a/tasks/lib/regexs.js
+++ b/tasks/lib/regexs.js
@@ -3,7 +3,7 @@
 module.exports = {
     relativePath: /^\.{1,2}\//,
     remote: /^http:|^https:|^\/\/|^data:image/i,
-    extension: /(\.[a-zA-Z0-9]{2,4})(|\?.*)(|#.*)$/,
+    extension: /(\.[a-zA-Z0-9]{2,5})(|\?.*)(|#.*)$/,
     urlFragHint: /'(([^']+)#grunt-cache-bust)'|"(([^"]+)#grunt-cache-bust)"/g,
     removeFragHint: /#grunt-cache-bust/g
 };

--- a/tests/rename/assets/fonts/icons.eot
+++ b/tests/rename/assets/fonts/icons.eot
@@ -1,0 +1,1 @@
+icons.eot

--- a/tests/rename/assets/fonts/icons.ttf
+++ b/tests/rename/assets/fonts/icons.ttf
@@ -1,0 +1,1 @@
+icons.tff

--- a/tests/rename/assets/fonts/icons.woff
+++ b/tests/rename/assets/fonts/icons.woff
@@ -1,0 +1,1 @@
+icons.woff

--- a/tests/rename/assets/fonts/icons.woff2
+++ b/tests/rename/assets/fonts/icons.woff2
@@ -1,0 +1,1 @@
+icons.woff2

--- a/tests/rename/rename.css
+++ b/tests/rename/rename.css
@@ -1,0 +1,10 @@
+@font-face {
+    font-family: icons;
+    src: url(/assets/fonts/icons.eot);
+    src: url(/assets/fonts/icons.eot?#iefix) format(embedded-opentype),
+         url(/assets/fonts/icons.woff) format(woff),
+         url(/assets/fonts/icons.woff2) format(woff2),
+         url(/assets/fonts/icons.ttf) format(truetype);
+    font-weight: 400;
+    font-style: normal;
+}

--- a/tests/rename/rename_test.js
+++ b/tests/rename/rename_test.js
@@ -19,6 +19,23 @@ module.exports = {
         test.done();
     },
 
+    renaming_css: function(test) {
+        test.expect(8);
+
+        var markup = grunt.file.read('tmp/rename/rename.css');
+
+        test.ok(markup.match(/assets\/fonts\/icons\.[a-z0-9]{16}\.eot/), 'testing renaming of fonts in CSS');
+        test.ok(grunt.file.exists('tmp/rename/' + markup.match(/assets\/fonts\/icons\.[a-z0-9]{16}\.eot/)[0]));
+        test.ok(markup.match(/assets\/fonts\/icons\.[a-z0-9]{16}\.woff/), 'testing the that multiple urls busted');
+        test.ok(grunt.file.exists('tmp/rename/' + markup.match(/assets\/fonts\/icons\.[a-z0-9]{16}\.woff/)[0]));
+        test.ok(markup.match(/assets\/fonts\/icons\.[a-z0-9]{16}\.woff2/), 'testing the that multiple urls busted');
+        test.ok(grunt.file.exists('tmp/rename/' + markup.match(/assets\/fonts\/icons\.[a-z0-9]{16}\.woff2/)[0]));
+        test.ok(markup.match(/assets\/fonts\/icons\.[a-z0-9]{16}\.ttf/), 'testing the that multiple urls busted');
+        test.ok(grunt.file.exists('tmp/rename/' + markup.match(/assets\/fonts\/icons\.[a-z0-9]{16}\.ttf/)[0]));
+
+        test.done();
+    },
+
     scriptsInDifferentFiles: function(test) {
         test.expect(6);
 

--- a/tests/stylesheets/assets/fonts/icons.woff2
+++ b/tests/stylesheets/assets/fonts/icons.woff2
@@ -1,0 +1,1 @@
+icons.woff2

--- a/tests/stylesheets/multipleUrls.css
+++ b/tests/stylesheets/multipleUrls.css
@@ -3,6 +3,7 @@
     src: url(/assets/fonts/icons.eot);
     src: url(/assets/fonts/icons.eot?#iefix) format(embedded-opentype),
          url(/assets/fonts/icons.woff) format(woff),
+         url(/assets/fonts/icons.woff2) format(woff2),
          url(/assets/fonts/icons.ttf) format(truetype);
     font-weight: 400;
     font-style: normal;

--- a/tests/stylesheets/stylesheet_test.js
+++ b/tests/stylesheets/stylesheet_test.js
@@ -51,7 +51,7 @@ module.exports = {
     },
 
     multipleUrls: function(test) {
-        test.expect(5);
+        test.expect(6);
 
         var markup = grunt.file.read('tmp/stylesheets/multipleUrls.css');
 
@@ -59,6 +59,7 @@ module.exports = {
         test.ok(markup.match(/assets\/fonts\/icons\.[a-z0-9]{16}\.eot\?#iefix/), 'testing the that multiple urls busted');
         test.ok(markup.match(/assets\/fonts\/icons\.[a-z0-9]{16}\.eot/), 'testing the that multiple urls busted');
         test.ok(markup.match(/assets\/fonts\/icons\.[a-z0-9]{16}\.woff/), 'testing the that multiple urls busted');
+        test.ok(markup.match(/assets\/fonts\/icons\.[a-z0-9]{16}\.woff2/), 'testing the that multiple urls busted');
         test.ok(markup.match(/assets\/fonts\/icons\.[a-z0-9]{16}\.ttf/), 'testing the that multiple urls busted');
 
         test.done();


### PR DESCRIPTION
While reading the file content during hashing, do not convert content to
string but process as non-decoded buffer. Interpretation as string result
in wrong hash values for binary files.