### PR TITLE
Fix v1 issues

### DIFF
--- a/tasks/cachebust.js
+++ b/tasks/cachebust.js
@@ -82,8 +82,9 @@ module.exports = function() {
         function addFileHash(str, hash, separator) {
             var parsed = url.parse(str);
             var ext = path.extname(parsed.pathname);
+            var extensionless = parsed.pathname.slice(0, -ext.length);
 
-            return (parsed.hostname ? parsed.protocol + parsed.hostname : '') + parsed.pathname.replace(ext, '') + separator + hash + ext;
+            return (parsed.hostname ? parsed.protocol + parsed.hostname : '') + extensionless + separator + hash + ext;
         }
 
     });

--- a/tasks/cachebust.js
+++ b/tasks/cachebust.js
@@ -30,6 +30,8 @@ module.exports = function() {
         // Generate an asset map
         var assetMap = grunt.file
             .expand(discoveryOpts, opts.assets)
+            .sort()
+            .reverse()
             .reduce(hashFile, {});
 
         console.log(assetMap);

--- a/tests/standard/assets/extensions.css.css
+++ b/tests/standard/assets/extensions.css.css
@@ -1,0 +1,1 @@
+/* This file tests that the extension is not removed twice */

--- a/tests/standard/standard.html
+++ b/tests/standard/standard.html
@@ -4,6 +4,7 @@
     <title>This is a test page</title>
 
     <link rel="stylesheet" href="assets/standard.css" />
+    <link rel="stylesheet" href="assets/extensions.css.css" />
 </head>
 <body>
     <img src="assets/standard.jpg" alt="bird">

--- a/tests/standard/standard_test.js
+++ b/tests/standard/standard_test.js
@@ -5,7 +5,7 @@ var grunt = require('grunt');
 module.exports = {
 
     standard: function(test) {
-        test.expect(3);
+        test.expect(4);
 
         var markup = grunt.file.read('tmp/standard/standard.html');
 
@@ -13,17 +13,21 @@ module.exports = {
         test.ok(markup.match(/assets\/standard\.[a-z0-9]{16}\.jpg/), 'testing assets/standard.jpg');
         test.ok(markup.match(/assets\/standard\.[a-z0-9]{16}\.js/ ), 'testing assets/standard.js');
 
+        test.ok(markup.match(/assets\/extensions\.css\.[a-z0-9]{16}\.css/), 'testing assets/extensions.css.css');
+
         test.done();
     },
 
     relative: function(test) {
-        test.expect(3);
+        test.expect(4);
 
         var markup = grunt.file.read('tmp/standard/subfolder/relative-standard.html');
 
         test.ok(markup.match(/assets\/standard\.[a-z0-9]{16}\.css/), 'testing relative file path of assets/standard.css');
         test.ok(markup.match(/assets\/standard\.[a-z0-9]{16}\.jpg/), 'testing relative file path of assets/standard.jpg');
         test.ok(markup.match(/assets\/standard\.[a-z0-9]{16}\.js/ ), 'testing relative file path of assets/standard.js');
+
+        test.ok(markup.match(/assets\/extensions\.css\.[a-z0-9]{16}\.css/), 'testing relative file path of assets/extensions.css.css');
 
         test.done();
     }

--- a/tests/standard/subfolder/relative-standard.html
+++ b/tests/standard/subfolder/relative-standard.html
@@ -4,6 +4,7 @@
     <title>This is a test page</title>
 
     <link rel="stylesheet" href="../assets/standard.css" />
+    <link rel="stylesheet" href="../assets/extensions.css.css" />
 </head>
 <body>
     <img src="../assets/standard.jpg" alt="bird">

--- a/tests/stylesheets/stylesheet_test.js
+++ b/tests/stylesheets/stylesheet_test.js
@@ -42,8 +42,8 @@ module.exports = {
         test.ok(markup.match(/assets\/fonts\/icons\.[a-z0-9]{16}\.eot/), 'testing the that multiple urls busted');
         test.ok(markup.match(/assets\/fonts\/icons\.[a-z0-9]{16}\.eot\?#iefix/), 'testing the that multiple urls busted');
         test.ok(markup.match(/assets\/fonts\/icons\.[a-z0-9]{16}\.eot/), 'testing the that multiple urls busted');
-        test.ok(markup.match(/assets\/fonts\/icons\.[a-z0-9]{16}\.woff/), 'testing the that multiple urls busted');
-        test.ok(markup.match(/assets\/fonts\/icons\.[a-z0-9]{16}\.woff2/), 'testing the that multiple urls busted');
+        test.ok(markup.match(/assets\/fonts\/icons\.303f279e24e9a1ed\.woff/), 'testing the that multiple urls busted');
+        test.ok(markup.match(/assets\/fonts\/icons\.f90c25689874683b\.woff2/), 'testing the that multiple urls busted');
         test.ok(markup.match(/assets\/fonts\/icons\.[a-z0-9]{16}\.ttf/), 'testing the that multiple urls busted');
 
         test.done();


### PR DESCRIPTION
This PR is an attempt at fixing the issues mentioned in #147.

- [x] Reverse the hash map so `font.woff2` is matched before `font.woff`.
- [x] Fix the way extensions are removed as this would have failed for a file called `test.css.css` (test case incoming)