### PR TITLE
Fix CSS processing for media queries with comments

### DIFF
--- a/tasks/lib/processCssFile.js
+++ b/tasks/lib/processCssFile.js
@@ -32,7 +32,10 @@ module.exports = function(data) {
     // Loop through each stylesheet rules
     cssObj.stylesheet.rules.forEach(function(rule) {
         var mediaQueryDeclarations = rule.type !== 'media' ? [] : rule.rules.reduce(function(acc, rule) {
-            return acc.concat(rule.declarations);
+            if (rule.declarations) {
+                return acc.concat(rule.declarations);
+            }
+            return acc;
         }, []);
 
         var declarations = (rule.declarations || []).concat(mediaQueryDeclarations);

--- a/tests/stylesheets/stylesheet.css
+++ b/tests/stylesheets/stylesheet.css
@@ -40,6 +40,7 @@ body {
 }
 
 @media only screen and (min-device-pixel-ratio: 2) and (min-resolution: 2dppx) {
+    /** Just a comment */
     .large-image {
         background-image: url('assets/image1.jpg');
     }


### PR DESCRIPTION
If a media query contains comments, the busting process is currently cancelled with the following error:
```
Cannot read property 'property' of undefined
```

The following CSS would break the current grunt task:
```css
@media only screen and (min-device-pixel-ratio: 2) and (min-resolution: 2dppx) {
    /* Just a comment */
    .large-image {
        background-image: url('assets/image1.jpg');
    }
}
```