### PR TITLE
Match all icon references

### DIFF
--- a/tasks/lib/defaultFilters.js
+++ b/tasks/lib/defaultFilters.js
@@ -31,7 +31,7 @@ module.exports = {
         }
         return undefined;
     },
-    'link[rel="icon"], link[rel="shortcut icon"]': function() {
+    'link[rel*="icon"]': function() {
         return this.attribs.href;
     },
     'script[type="text/template"]': function() {},


### PR DESCRIPTION
This could also match:

- `rel=apple-touch-icon`
- `rel=mask-icon`
- `rel=fluid-icon`
- every link ref that contains `icon`