### PR TITLE
fix: gracefully use default for assets

### DIFF
--- a/tasks/cachebust.js
+++ b/tasks/cachebust.js
@@ -31,7 +31,7 @@ module.exports = function() {
 
         // Generate an asset map
         var assetMap = grunt.file
-            .expand(discoveryOpts, opts.assets)
+            .expand(discoveryOpts, opts.assets || [])
             .sort()
             .reverse()
             .reduce(hashFile, {});


### PR DESCRIPTION
- If the assets key is not set in the options object (i.e. the files array has all of the listed assets desired), set to default to an empty array

This gracefully handles the situation where one is not using `options.assets` - Grunt expects it to be an array of strings, so it being undefined causes Grunt to error.