### PR TITLE
Added Support For Nested Mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The `src` part of the configuration you should have seen before as it's used by 
 #### Summary
 
 ```
-// Here is a short summary of the options and some of their 
+// Here is a short summary of the options and some of their
 defaults. Extra details are below.
 {
     algorithm: 'md5',                             // Algorithm used for hashing files
@@ -83,7 +83,9 @@ defaults. Extra details are below.
     jsonOutputFilename: 'grunt-cache-bust.json',  // The file path and name of the exported JSON. Is relative to baseDir
     length: 16,                                   // The length of the hash value
     separator: '.',                               // The separator between the original file name and hash
-    queryString: false                            // Use a query string for cache busting instead of rewriting files
+    queryString: false,                           // Use a query string for cache busting instead of rewriting files
+    nestedMappings: false,                        // Create Nested Mapping for the same file
+    nestedMappingsPattern: []                     // Array of Objects with pattern and splitAt values
 }
 ```
 
@@ -178,6 +180,55 @@ Type: `Boolean`
 Default value: `false`
 
 Use a query string for cache busting instead of rewriting files.
+
+#### options.nestedMappings
+Type: `Boolean`  
+Default value: `false`
+
+When set as `true`, it will create nested Mapping for the same filename as per the given pattern in `nestedMappingsPattern`
+
+#### options.nestedMappingsPattern
+Type: `Array`  
+Default value: `[]`
+
+Add Array of Objects with `pattern` and `splitAt` as keys.
+
+Example
+```js
+cacheBust: {
+    generate: {
+        options: {
+            assets: ['**'],
+            baseDir: 'build/',
+            jsonOutputFilename:'staticFilesCacheMapping.json',
+            jsonOutput: true,
+            nestedMappings: true,
+            nestedMappingsPattern: [
+                {
+                    pattern: 'assets/images/',
+                    splitAt: 'assets/'
+                },
+                {
+                    pattern: 'assets/fonts/',
+                    splitAt: 'assets/'
+                },
+            ]
+        },
+        src: ['build/assets/**/*.css']
+    }
+}
+```
+
+It will create the staticFilesCacheMapping.json like :
+
+```
+{
+  "assets/fonts/myCustomFont/myFont_semibold-webfont.woff2":"assets/fonts/myCustomFont/myFont_semibold-webfont.62772b8a9895121d.woff2",
+  "fonts/myCustomFont/myFont_semibold-webfont.woff":"fonts/myCustomFont/myFont_semibold-webfont.d842eed1cd97157c.woff",
+  "assets/images/homepage/uncle.png":"assets/images/homepage/uncle.1cce4a56e28c269b.png",
+  "images/homepage/trust-seal.png":"images/homepage/trust-seal.6ffe0c838d82331e.png"
+}
+```
 
 ### Usage Examples
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-cache-bust",
   "description": "Bust static assets from the cache using content hashing",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "author": "Ben Holland <hi@benholland.me>",
   "repository": {
     "type": "git",

--- a/tasks/cachebust.js
+++ b/tasks/cachebust.js
@@ -17,7 +17,9 @@ var DEFAULT_OPTIONS = {
     jsonOutputFilename: 'grunt-cache-bust.json',
     length: 16,
     separator: '.',
-    queryString: false
+    queryString: false,
+    nestedMappings: false,
+    nestedMappingsPattern: []
 };
 
 module.exports = function() {
@@ -71,6 +73,18 @@ module.exports = function() {
                 if (opts.deleteOriginals) {
                     grunt.file.delete(absPath);
                 }
+            }
+
+            if (opts.nestedMappings) {
+                opts.nestedMappingsPattern.map(function(mapping) {
+                    if (file.match(mapping.pattern)) {
+                        var splitAt = mapping.splitAt;
+                        var nestedFile = file.split(splitAt)[1];
+                        var newNestedFilename = newFilename.split(splitAt)[1];
+
+                        obj[nestedFile] = newNestedFilename;
+                    }
+                });
             }
 
             obj[file] = newFilename;


### PR DESCRIPTION
This is an additional Feature, to support the relative paths generated after compiling scss through 'compass'.

This PR adds the opt-in feature which adds the nested mapping of the assets.

As of now, all the links to asset files which are mapped are searched in all the files to be busted[replace the old link to assets to new mapped hashed links]

For E.g.
<img src="assets/images/homepage/myProfile.img"> 
Will be mapped with
<img src="assets/images/homepage/myProfile.ah21as.img"> 
 
But for the case when we are dealing with relative paths, the links wouldn't be replaced.
For E.g.
<img src="../images/homepage/myProfile.img">

For the above case, there would be no change in the file as it could not find
"assets/images/homepage/myProfile.img" to be replaced by "assets/images/homepage/myProfile.ah21as.img"

To support the feature all we need is add the following option in gruntfile: 

            nestedMappings: true,
            nestedMappingsPattern: [
                {
                    pattern: 'assets/images/',
                    splitAt: 'assets/'
                }
            ]
 
I have also updated the Readme file for instructions to use it.
