### PR TITLE
Make fs-extra a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "fs-extra": "^0.30.0",
     "grunt": "^1.0.1",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-copy": "^1.0.0",
@@ -37,5 +36,8 @@
     "cache",
     "bust",
     "bust assets"
-  ]
+  ],
+  "dependencies": {
+    "fs-extra": "^0.30.0"
+  }
 }


### PR DESCRIPTION
Fixes #204 by moving `fs-extra` to the dependencies section in the `package.json` file.