### PR TITLE
Fix for clearOutputDir option.

### DIFF
--- a/tasks/cachebust.js
+++ b/tasks/cachebust.js
@@ -35,7 +35,7 @@ module.exports = function(grunt) {
 
         //clear output dir if it was set
         if (opts.clearOutputDir && opts.outputDir.length > 0) {
-            fs.removeSync(path.resolve((discoveryOpts.cwd ? discoveryOpts.cwd + opts.clearOutputDir : opts.clearOutputDir)));
+            fs.removeSync(path.resolve((discoveryOpts.cwd ? discoveryOpts.cwd + '/' +opts.outputDir : opts.outputDir)));
         }
 
         // Generate an asset map


### PR DESCRIPTION
Setting true for **clearOutputDir** option was not working since the path concatenation logic was wrong.

There were two issues:
1. Needed to use a slash between the "cwd" and "outputDir"
2. "clearOutputDir" was used instead of "outputDir" in the path concatenation