### PR TITLE
Windows paths use backspace when you use the code node js pathmodules

### DIFF
--- a/tasks/cachebust.js
+++ b/tasks/cachebust.js
@@ -108,7 +108,11 @@ module.exports = function(grunt) {
             var fileDepth = 0;
 
             if (relativeFileDir !== '') {
-                fileDepth = relativeFileDir.split('/').length;
+                if(process.platform === "win32"){
+                    fileDepth = relativeFileDir.split('/').length;
+                }else{
+                    fileDepth = relativeFileDir.split('/').length;
+                }
             }
 
             var baseDirs = filepath.substr(baseDir.length).split('/');


### PR DESCRIPTION
Without this line the depth is never correct on windows