### PR TITLE
 Windows paths use backspace when you use the code node js pathmodules

### DIFF
--- a/tasks/cachebust.js
+++ b/tasks/cachebust.js
@@ -108,7 +108,11 @@ module.exports = function(grunt) {
             var fileDepth = 0;
 
             if (relativeFileDir !== '') {
-                fileDepth = relativeFileDir.split('/').length;
+                if(process.platform === "win32"){
+                    fileDepth = relativeFileDir.split('/').length;
+                }else{
+                    fileDepth = relativeFileDir.split('/').length;
+                }
             }
 
             var baseDirs = filepath.substr(baseDir.length).split('/');

--- a/tasks/cachebust.js
+++ b/tasks/cachebust.js
@@ -109,7 +109,7 @@ module.exports = function(grunt) {
 
             if (relativeFileDir !== '') {
                 if(process.platform === "win32"){
-                    fileDepth = relativeFileDir.split('/').length;
+                    fileDepth = relativeFileDir.split('\\').length;
                 }else{
                     fileDepth = relativeFileDir.split('/').length;
                 }


### PR DESCRIPTION
Without this line the depth is not correct on windows